### PR TITLE
Remove wodge-button container background color on hover

### DIFF
--- a/style/css/main.css
+++ b/style/css/main.css
@@ -4286,6 +4286,18 @@ padding: 1.3em 0 0.5em 0;
     margin-bottom: 16px;
 }
 
+/* v2.1 
+ * FIX FOR WODGE-BUTTON
+ * Note: wodge-button inherits from the [*='button'] class. On hover, the background of this container div turns blue.
+ * This overrides these styels.
+ */
+
+.wodge-button:hover,
+.wodge-button:active,
+.wodge-button:focus {
+    background-color: transparent !important; /* requires important! because button class has high specificity */
+}
+
 /* @end Wodge */
 
 /* @group Global Header */


### PR DESCRIPTION
This will solve codeforamerica/codeforamerica.org#1017.

With this commit, we're now developing/shipping v2.1 of the pattern-library.

**What this solves**

We treat every class with -button in the name as a button due to a star selector ([class=*"-button"]). .wodge-button isn't a button, but a container for buttons. However, .wodge-button inherited the button styles, and on hover the whole container div was getting a blue background color.

![wodge-hover](https://cloud.githubusercontent.com/assets/6456757/7310955/ce427fc4-e9e9-11e4-825f-7f16ce6ec836.gif)

I'm using !important to override that behavior because the *button class has a very high degree of specificity. In the future, we should consider renaming wodge-button to something else, and reserving the button namespace for buttons alone.
