### PR TITLE
Add margin back to masthead on mobile, remove on desktop

### DIFF
--- a/style/css/main.css
+++ b/style/css/main.css
@@ -1914,9 +1914,17 @@ input.button-s {
 
 .masthead {
     clear: both;
+    margin-top: 60px;
     overflow: hidden;
     position: relative;
     text-align: center;
+}
+
+@media (min-width: 40em) {
+  /* collapse margin on masthead on tablet-size up */
+  .masthead {
+    margin-top: 0;
+  }
 }
 
 .masthead:before {


### PR DESCRIPTION
We'll need the masthead to have a margin on small screens, but not on large screens.
